### PR TITLE
refactor: use sha1 for rate limit key generation

### DIFF
--- a/src/WithRateLimiting.php
+++ b/src/WithRateLimiting.php
@@ -20,7 +20,7 @@ trait WithRateLimiting
     {
         if (! $method) $method = debug_backtrace()[1]['function'];
 
-        return static::class.'|'.$method.'|'.request()->ip();
+        return sha1(static::class.'|'.$method.'|'.request()->ip());
     }
 
     protected function hitRateLimiter($method = null, $decaySeconds = 60)


### PR DESCRIPTION
This adjusts the rate limit key to be a `sha1` hash of the values to avoid using user-identifiable data such as their IP, as discussed in https://github.com/danharrin/livewire-rate-limiting/discussions/12. This also brings it in line with Laravel's own approach to key generation for throttling, as can be seen here: https://github.com/laravel/framework/blob/9.x/src/Illuminate/Routing/Middleware/ThrottleRequests.php#L172

Chances of accidental collisions using this scheme are practically zero: https://crypto.stackexchange.com/questions/2583/is-it-fair-to-assume-that-sha1-collisions-wont-occur-on-a-set-of-100k-strings

If anything else is required, please let me know.