### PR TITLE
Key class customizable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "illuminate/support": "^9.0|^10.0"
     },
     "require-dev": {
-        "livewire/livewire": "^2.3",
+        "livewire/livewire": "^3.0",
+        "livewire/volt": "^1.3",
         "orchestra/testbench": "^7.0|^8.0",
         "phpunit/phpunit": "^9.0|^10.0"
     },

--- a/src/Exceptions/TooManyRequestsException.php
+++ b/src/Exceptions/TooManyRequestsException.php
@@ -12,15 +12,18 @@ class TooManyRequestsException extends Exception
 
     public $method;
 
+    public $class;
+
     public $minutesUntilAvailable;
 
     public $secondsUntilAvailable;
 
-    public function __construct($component, $method, $ip, $secondsUntilAvailable)
+    public function __construct($component, $method, $ip, $secondsUntilAvailable, $class)
     {
         $this->component = $component;
         $this->ip = $ip;
         $this->method = $method;
+        $this->class = $class;
         $this->secondsUntilAvailable = $secondsUntilAvailable;
 
         $this->minutesUntilAvailable = ceil($this->secondsUntilAvailable / 60);
@@ -31,6 +34,7 @@ class TooManyRequestsException extends Exception
             $this->method,
             $this->component,
             $this->secondsUntilAvailable,
+            $this->class,
         ));
     }
 }

--- a/src/Exceptions/TooManyRequestsException.php
+++ b/src/Exceptions/TooManyRequestsException.php
@@ -13,7 +13,6 @@ class TooManyRequestsException extends Exception
         public $method,
         public $ip,
         public $secondsUntilAvailable,
-        public $component = null,
     ) {
         $this->minutesUntilAvailable = ceil($this->secondsUntilAvailable / 60);
 
@@ -23,7 +22,6 @@ class TooManyRequestsException extends Exception
             $this->method,
             $this->component,
             $this->secondsUntilAvailable,
-            $this->component,
         ));
     }
 }

--- a/src/Exceptions/TooManyRequestsException.php
+++ b/src/Exceptions/TooManyRequestsException.php
@@ -13,7 +13,7 @@ class TooManyRequestsException extends Exception
         public $method,
         public $ip,
         public $secondsUntilAvailable,
-        public $class = null,
+        public $component = null,
     ) {
         $this->minutesUntilAvailable = ceil($this->secondsUntilAvailable / 60);
 
@@ -23,7 +23,7 @@ class TooManyRequestsException extends Exception
             $this->method,
             $this->component,
             $this->secondsUntilAvailable,
-            $this->class,
+            $this->component,
         ));
     }
 }

--- a/src/WithRateLimiting.php
+++ b/src/WithRateLimiting.php
@@ -11,7 +11,7 @@ trait WithRateLimiting
     {
         $method ??= debug_backtrace(limit: 2)[1]['function'];
 
-        if (! $class) $class = static::class;
+        $class ??= static::class;
 
         $key = $this->getRateLimitKey($method, $class);
 
@@ -22,7 +22,7 @@ trait WithRateLimiting
     {
         $method ??= debug_backtrace(limit: 2)[1]['function'];
 
-        if (! $class) $class = static::class;
+        $class ??= static::class;
 
         return sha1($class.'|'.$method.'|'.request()->ip());
     }
@@ -31,7 +31,7 @@ trait WithRateLimiting
     {
         $method ??= debug_backtrace(limit: 2)[1]['function'];
 
-        if (! $class) $class = static::class;
+        $class ??= static::class;
 
         $key = $this->getRateLimitKey($method, $class);
 
@@ -42,7 +42,7 @@ trait WithRateLimiting
     {
         $method ??= debug_backtrace(limit: 2)[1]['function'];
 
-        if (! $class) $class = static::class;
+        $class ??= static::class;
 
         $key = $this->getRateLimitKey($method, $class);
 

--- a/src/WithRateLimiting.php
+++ b/src/WithRateLimiting.php
@@ -7,53 +7,52 @@ use Illuminate\Support\Facades\RateLimiter;
 
 trait WithRateLimiting
 {
-    protected function clearRateLimiter($method = null, $class = null)
+    protected function clearRateLimiter($method = null, $component = null)
     {
         $method ??= debug_backtrace(limit: 2)[1]['function'];
 
-        $class ??= static::class;
+        $component ??= static::class;
 
-        $key = $this->getRateLimitKey($method, $class);
+        $key = $this->getRateLimitKey($method, $component);
 
         RateLimiter::clear($key);
     }
 
-    protected function getRateLimitKey($method, $class)
+    protected function getRateLimitKey($method, $component)
     {
         $method ??= debug_backtrace(limit: 2)[1]['function'];
 
-        $class ??= static::class;
+        $component ??= static::class;
 
-        return sha1($class.'|'.$method.'|'.request()->ip());
+        return sha1($component.'|'.$method.'|'.request()->ip());
     }
 
-    protected function hitRateLimiter($method = null, $decaySeconds = 60, $class = null)
+    protected function hitRateLimiter($method = null, $decaySeconds = 60, $component = null)
     {
         $method ??= debug_backtrace(limit: 2)[1]['function'];
 
-        $class ??= static::class;
+        $component ??= static::class;
 
-        $key = $this->getRateLimitKey($method, $class);
+        $key = $this->getRateLimitKey($method, $component);
 
         RateLimiter::hit($key, $decaySeconds);
     }
 
-    protected function rateLimit($maxAttempts, $decaySeconds = 60, $method = null, $class = null)
+    protected function rateLimit($maxAttempts, $decaySeconds = 60, $method = null, $component = null)
     {
         $method ??= debug_backtrace(limit: 2)[1]['function'];
 
-        $class ??= static::class;
+        $component ??= static::class;
 
-        $key = $this->getRateLimitKey($method, $class);
+        $key = $this->getRateLimitKey($method, $component);
 
         if (RateLimiter::tooManyAttempts($key, $maxAttempts)) {
-            $component = static::class;
             $ip = request()->ip();
             $secondsUntilAvailable = RateLimiter::availableIn($key);
 
-            throw new TooManyRequestsException($component, $method, $ip, $secondsUntilAvailable, $class);
+            throw new TooManyRequestsException($component, $method, $ip, $secondsUntilAvailable);
         }
 
-        $this->hitRateLimiter($method, $decaySeconds, $class);
+        $this->hitRateLimiter($method, $decaySeconds, $component);
     }
 }

--- a/tests/RateLimitingTest.php
+++ b/tests/RateLimitingTest.php
@@ -4,6 +4,7 @@ namespace DanHarrin\LivewireRateLimiting\Tests;
 
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use Livewire\Livewire;
+use Livewire\Volt\Volt;
 
 class RateLimitingTest extends TestCase
 {
@@ -41,6 +42,51 @@ class RateLimitingTest extends TestCase
             ->call('clear')
             ->call('limit')
             ->assertSet('secondsUntilAvailable', 0);
+    }
+
+    /** @test */
+    public function can_rate_limit_volt()
+    {
+        $this->mountVolt();
+        $component = Volt::test('volt-component');
+
+        $component
+            ->call('limit')
+            ->assertSet('secondsUntilAvailable', 0)
+            ->call('limit')
+            ->assertSet('secondsUntilAvailable', 0)
+            ->call('limit')
+            ->assertSet('secondsUntilAvailable', 0)
+            ->call('limit')
+            ->assertNotSet('secondsUntilAvailable', 0);
+
+        sleep(1);
+
+        $component
+            ->call('limit')
+            ->assertSet('secondsUntilAvailable', 0);
+    }
+
+    /** @test */
+    public function can_hit_and_clear_rate_limiter_volt()
+    {
+        $this->mountVolt();
+        Volt::test('volt-component')
+            ->call('hit')
+            ->call('hit')
+            ->call('hit')
+            ->call('limit')
+            ->assertNotSet('secondsUntilAvailable', 0)
+            ->call('clear')
+            ->call('limit')
+            ->assertSet('secondsUntilAvailable', 0);
+    }
+
+    protected function mountVolt()
+    {
+        Volt::mount([
+            __DIR__ . '/views',
+        ]);
     }
 }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,8 @@
 namespace DanHarrin\LivewireRateLimiting\Tests;
 
 use Livewire\LivewireServiceProvider;
+use Livewire\Volt\Volt;
+use Livewire\Volt\VoltServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -20,6 +22,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
     {
         return [
             LivewireServiceProvider::class,
+            VoltServiceProvider::class,
         ];
     }
 }

--- a/tests/views/volt-component.blade.php
+++ b/tests/views/volt-component.blade.php
@@ -10,18 +10,18 @@ new class extends Component {
 
     public function clear()
     {
-        $this->clearRateLimiter('limit', class: 'VoltComponent');
+        $this->clearRateLimiter('limit', component: 'VoltComponent');
     }
 
     public function hit()
     {
-        $this->hitRateLimiter('limit', 1, class: 'VoltComponent');
+        $this->hitRateLimiter('limit', 1, component: 'VoltComponent');
     }
 
     public function limit()
     {
         try {
-            $this->rateLimit(3, 1, class: 'VoltComponent');
+            $this->rateLimit(3, 1, component: 'VoltComponent');
         } catch (TooManyRequestsException $exception) {
             return $this->secondsUntilAvailable = $exception->secondsUntilAvailable;
         }

--- a/tests/views/volt-component.blade.php
+++ b/tests/views/volt-component.blade.php
@@ -1,0 +1,36 @@
+<?php
+
+use Livewire\Volt\Component;
+use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+
+new class extends Component {
+    use \DanHarrin\LivewireRateLimiting\WithRateLimiting;
+
+    public $secondsUntilAvailable;
+
+    public function clear()
+    {
+        $this->clearRateLimiter('limit', class: 'VoltComponent');
+    }
+
+    public function hit()
+    {
+        $this->hitRateLimiter('limit', 1, class: 'VoltComponent');
+    }
+
+    public function limit()
+    {
+        try {
+            $this->rateLimit(3, 1, class: 'VoltComponent');
+        } catch (TooManyRequestsException $exception) {
+            return $this->secondsUntilAvailable = $exception->secondsUntilAvailable;
+        }
+
+        $this->secondsUntilAvailable = 0;
+    }
+
+}; ?>
+
+<div>
+    //
+</div>


### PR DESCRIPTION
Currently, the package use `static::class` along with function name and request ip to create rate limit key

```php
return sha1(static::class.'|'.$method.'|'.request()->ip());
```

But the new Volt has the syntax **define an anonymous class** that extends Livewire\Volt\Component. This will make the `static::class` return different value each request. For example:

```
resources/views/pages/register.blade.php:9$2a6
```

```
resources/views/pages/register.blade.php:9$28
```

So, I make a small update that add ability to customize class name, just like method name