### PR TITLE
fix: default to `null` for getRateLimitKey component

### DIFF
--- a/src/WithRateLimiting.php
+++ b/src/WithRateLimiting.php
@@ -18,7 +18,7 @@ trait WithRateLimiting
         RateLimiter::clear($key);
     }
 
-    protected function getRateLimitKey($method, $component)
+    protected function getRateLimitKey($method, $component = null)
     {
         $method ??= debug_backtrace(limit: 2)[1]['function'];
 


### PR DESCRIPTION
with https://github.com/danharrin/livewire-rate-limiting/pull/20 a custom component parameter was added, but this causes  backwards compatibility issues when using the `getRateLimitKey` method as it's not an optional parameter for that method.

This PR makes the component optional in that method as well