### PR TITLE
test: add php 8.4 to CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.3, 8.2 ]
+        php: [ 8.4, 8.3, 8.2 ]
         laravel: [ 11.*, 10.* ]
         dependency-version: [ prefer-stable ]
         include:


### PR DESCRIPTION
This PR updates the GitHub action with PHP 8.4. 