### PR TITLE
Ignores args

### DIFF
--- a/src/WithRateLimiting.php
+++ b/src/WithRateLimiting.php
@@ -7,52 +7,52 @@ use Illuminate\Support\Facades\RateLimiter;
 
 trait WithRateLimiting
 {
-    protected function clearRateLimiter($method = null, $component = null)
+    protected function clearRateLimiter($target = null, $component = null)
     {
-        $method ??= debug_backtrace(limit: 2)[1]['function'];
+        $target ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
 
         $component ??= static::class;
 
-        $key = $this->getRateLimitKey($method, $component);
+        $key = $this->getRateLimitKey($target, $component);
 
         RateLimiter::clear($key);
     }
 
-    protected function getRateLimitKey($method, $component = null)
+    protected function getRateLimitKey($target, $component = null)
     {
-        $method ??= debug_backtrace(limit: 2)[1]['function'];
+        $target ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
 
         $component ??= static::class;
 
-        return 'livewire-rate-limiter:'.sha1($component.'|'.$method.'|'.request()->ip());
+        return 'livewire-rate-limiter:'.sha1($component.'|'.$target.'|'.request()->ip());
     }
 
-    protected function hitRateLimiter($method = null, $decaySeconds = 60, $component = null)
+    protected function hitRateLimiter($target = null, $decaySeconds = 60, $component = null)
     {
-        $method ??= debug_backtrace(limit: 2)[1]['function'];
+        $target ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
 
         $component ??= static::class;
 
-        $key = $this->getRateLimitKey($method, $component);
+        $key = $this->getRateLimitKey($target, $component);
 
         RateLimiter::hit($key, $decaySeconds);
     }
 
-    protected function rateLimit($maxAttempts, $decaySeconds = 60, $method = null, $component = null)
+    protected function rateLimit($maxAttempts, $decaySeconds = 60, $target = null, $component = null)
     {
-        $method ??= debug_backtrace(limit: 2)[1]['function'];
+        $target ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
 
         $component ??= static::class;
 
-        $key = $this->getRateLimitKey($method, $component);
+        $key = $this->getRateLimitKey($target, $component);
 
         if (RateLimiter::tooManyAttempts($key, $maxAttempts)) {
             $ip = request()->ip();
             $secondsUntilAvailable = RateLimiter::availableIn($key);
 
-            throw new TooManyRequestsException($component, $method, $ip, $secondsUntilAvailable);
+            throw new TooManyRequestsException($component, $target, $ip, $secondsUntilAvailable);
         }
 
-        $this->hitRateLimiter($method, $decaySeconds, $component);
+        $this->hitRateLimiter($target, $decaySeconds, $component);
     }
 }

--- a/src/WithRateLimiting.php
+++ b/src/WithRateLimiting.php
@@ -9,7 +9,7 @@ trait WithRateLimiting
 {
     protected function clearRateLimiter($method = null, $component = null)
     {
-        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
+        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, limit: 2)[1]['function'];
 
         $component ??= static::class;
 
@@ -20,7 +20,7 @@ trait WithRateLimiting
 
     protected function getRateLimitKey($method, $component = null)
     {
-        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
+        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, limit: 2)[1]['function'];
 
         $component ??= static::class;
 
@@ -29,7 +29,7 @@ trait WithRateLimiting
 
     protected function hitRateLimiter($method = null, $decaySeconds = 60, $component = null)
     {
-        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
+        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, limit: 2)[1]['function'];
 
         $component ??= static::class;
 
@@ -40,7 +40,7 @@ trait WithRateLimiting
 
     protected function rateLimit($maxAttempts, $decaySeconds = 60, $method = null, $component = null)
     {
-        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
+        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, limit: 2)[1]['function'];
 
         $component ??= static::class;
 

--- a/src/WithRateLimiting.php
+++ b/src/WithRateLimiting.php
@@ -7,52 +7,52 @@ use Illuminate\Support\Facades\RateLimiter;
 
 trait WithRateLimiting
 {
-    protected function clearRateLimiter($target = null, $component = null)
+    protected function clearRateLimiter($method = null, $component = null)
     {
-        $target ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
+        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
 
         $component ??= static::class;
 
-        $key = $this->getRateLimitKey($target, $component);
+        $key = $this->getRateLimitKey($method, $component);
 
         RateLimiter::clear($key);
     }
 
-    protected function getRateLimitKey($target, $component = null)
+    protected function getRateLimitKey($method, $component = null)
     {
-        $target ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
+        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
 
         $component ??= static::class;
 
-        return 'livewire-rate-limiter:'.sha1($component.'|'.$target.'|'.request()->ip());
+        return 'livewire-rate-limiter:'.sha1($component.'|'.$method.'|'.request()->ip());
     }
 
-    protected function hitRateLimiter($target = null, $decaySeconds = 60, $component = null)
+    protected function hitRateLimiter($method = null, $decaySeconds = 60, $component = null)
     {
-        $target ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
+        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
 
         $component ??= static::class;
 
-        $key = $this->getRateLimitKey($target, $component);
+        $key = $this->getRateLimitKey($method, $component);
 
         RateLimiter::hit($key, $decaySeconds);
     }
 
-    protected function rateLimit($maxAttempts, $decaySeconds = 60, $target = null, $component = null)
+    protected function rateLimit($maxAttempts, $decaySeconds = 60, $method = null, $component = null)
     {
-        $target ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
+        $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
 
         $component ??= static::class;
 
-        $key = $this->getRateLimitKey($target, $component);
+        $key = $this->getRateLimitKey($method, $component);
 
         if (RateLimiter::tooManyAttempts($key, $maxAttempts)) {
             $ip = request()->ip();
             $secondsUntilAvailable = RateLimiter::availableIn($key);
 
-            throw new TooManyRequestsException($component, $target, $ip, $secondsUntilAvailable);
+            throw new TooManyRequestsException($component, $method, $ip, $secondsUntilAvailable);
         }
 
-        $this->hitRateLimiter($target, $decaySeconds, $component);
+        $this->hitRateLimiter($method, $decaySeconds, $component);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,6 @@
 namespace DanHarrin\LivewireRateLimiting\Tests;
 
 use Livewire\LivewireServiceProvider;
-use Livewire\Volt\Volt;
 use Livewire\Volt\VoltServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase


### PR DESCRIPTION
Ignore args and change $method to $target based on 'wire:target' for shared rate limiters.