### PR TITLE
Add a .gitattributes file to exclude the tests and ci files from archive export used by composer.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-/.github                export-ignore
-/tests                  export-ignore
-/phpunit.xml.dist       export-ignore
+/.github export-ignore
+/phpunit.xml.dist export-ignore
+/tests export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/.github                export-ignore
+/tests                  export-ignore
+/phpunit.xml.dist       export-ignore


### PR DESCRIPTION
Add a .gitattributes file to exclude the tests and ci files from the archive export used by composer.
See: https://www.git-scm.com/docs/gitattributes#_creating_an_archive