### PR TITLE
Adds RateLimit livewire attribute for simple usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,50 @@ This package is tested to support the `file` and `redis` cache drivers, but not 
 
 ## Usage
 
+### Basic usage with attribute
+
+Use the `DanHarrin\LivewireRateLimiting\Attributes\RateLimit` attribute together with your Livewire method in order to easily rate limit a method (Throws a `DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException`):
+
+```php
+<?php
+
+namespace App\Http\Livewire\Login;
+
+use DanHarrin\LivewireRateLimiting\Attributes\RateLimit;
+use Livewire\Component;
+
+class Login extends Component
+{
+    #[RateLimit(maxAttempts: 10)]
+    public function submit()
+    {
+        // ...
+    }
+}
+```
+
+The RateLimit attribute also comes with built in support for displaying error messages instead of throwing an exception:
+
+```php
+<?php
+
+namespace App\Http\Livewire\Login;
+
+use DanHarrin\LivewireRateLimiting\Attributes\RateLimit;
+use Livewire\Component;
+
+class Login extends Component
+{
+    #[RateLimit(maxAttempts: 10, validationErrors: ['email' => 'Too many attempts...'])]
+    public function submit()
+    {
+        // ...
+    }
+}
+```
+
+### Advanced usage with full control of rate limiting
+
 Apply the `DanHarrin\LivewireRateLimiting\WithRateLimiting` trait to your Livewire component:
 
 ```php

--- a/src/Attributes/RateLimit.php
+++ b/src/Attributes/RateLimit.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DanHarrin\LivewireRateLimiting\Attributes;
+
+use Attribute;
+use DanHarrin\LivewireRateLimiting\WithRateLimiting;
+use Livewire\Features\SupportAttributes\Attribute as LivewireAttribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class RateLimit extends LivewireAttribute
+{
+    use WithRateLimiting;
+
+    public function __construct(
+        private int $maxAttempts,
+        private int $decaySeconds = 60,
+        private array $validationErrors = [],
+        private ?string $methodName = null,
+    ) {
+    }
+
+    public function call($params, $returnEarly): void
+    {
+        rescue(function () {
+            $this->rateLimit($this->maxAttempts, method: $this->methodName ?: $this->getName());
+        }, function ($e) use ($returnEarly) {
+            if (count($this->validationErrors) === 0) {
+                throw $e;
+            }
+
+            $this->component->setErrorBag($this->validationErrors);
+            $returnEarly();
+        });
+    }
+}

--- a/tests/RateLimitAttributeTest.php
+++ b/tests/RateLimitAttributeTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace DanHarrin\LivewireRateLimiting\Tests;
+
+use DanHarrin\LivewireRateLimiting\Attributes\RateLimit;
+use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use Livewire\Livewire;
+use Livewire\Volt\Volt;
+
+class RateLimitAttributeTest extends TestCase
+{
+    /** @test */
+    public function can_rate_limit_and_throw_basic_exception()
+    {
+        $this->expectException(TooManyRequestsException::class);
+
+        Livewire::test(AttributeComponent::class)
+            ->call('increment')
+            ->assertSet('counter', 1)
+            ->call('increment')
+            ->assertSet('counter', 2)
+            ->call('increment');
+    }
+
+    /** @test */
+    public function can_display_errors_when_rate_limiting()
+    {
+        Livewire::test(AttributeComponent::class)
+            ->call('incrementWithValidationErrors')
+            ->assertSet('counter', 1)
+            ->call('incrementWithValidationErrors')
+            ->assertSet('counter', 2)
+            ->call('incrementWithValidationErrors')
+            ->assertSet('counter', 2)
+            ->assertHasErrors(['firstname' => 'Too many requests.']);
+    }
+
+    /** @test */
+    public function can_rate_limit_and_throw_basic_exception_volt()
+    {
+        $this->mountVolt();
+        $this->expectException(TooManyRequestsException::class);
+
+        Volt::test('volt-attribute-component')
+            ->call('increment')
+            ->assertSet('counter', 1)
+            ->call('increment')
+            ->assertSet('counter', 2)
+            ->call('increment');
+    }
+
+    /** @test */
+    public function can_display_errors_when_rate_limiting_volt()
+    {
+        $this->mountVolt();
+
+        Volt::test('volt-attribute-component')
+            ->call('incrementWithValidationErrors')
+            ->assertSet('counter', 1)
+            ->call('incrementWithValidationErrors')
+            ->assertSet('counter', 2)
+            ->call('incrementWithValidationErrors')
+            ->assertSet('counter', 2)
+            ->assertHasErrors(['firstname' => 'Too many requests.']);
+    }
+
+    protected function mountVolt()
+    {
+        Volt::mount([
+            __DIR__ . '/views',
+        ]);
+    }
+}
+
+class AttributeComponent extends \Livewire\Component
+{
+    public int $counter = 0;
+
+    #[RateLimit(maxAttempts: 2)]
+    public function increment(): void
+    {
+        $this->counter++;
+    }
+
+    #[RateLimit(maxAttempts: 2, validationErrors: ['firstname' => 'Too many requests.'])]
+    public function incrementWithValidationErrors(): void
+    {
+        $this->counter++;
+    }
+
+    public function render()
+    {
+        return view('component');
+    }
+}

--- a/tests/views/volt-attribute-component.blade.php
+++ b/tests/views/volt-attribute-component.blade.php
@@ -1,0 +1,24 @@
+<?php
+
+use DanHarrin\LivewireRateLimiting\Attributes\RateLimit;
+use Livewire\Volt\Component;
+
+new class extends Component {
+    public int $counter = 0;
+
+    #[RateLimit(maxAttempts: 2)]
+    public function increment(): void
+    {
+        $this->counter++;
+    }
+
+    #[RateLimit(maxAttempts: 2, validationErrors: ['firstname' => 'Too many requests.'])]
+    public function incrementWithValidationErrors(): void
+    {
+        $this->counter++;
+    }
+}; ?>
+
+<div>
+    //
+</div>


### PR DESCRIPTION
First of all, thanks for the package. I've recently been using it in a project and it works great!

For my use case, the most important thing is being able to easily throw display validation errors when the rate limit occurs. In order to simplify this, I created a livewire attribute which gives a simple api for rate limiting a livewire method.

With the RateLimit attribute, you can rate limit a given livewire method like this:

```php
<?php

namespace App\Http\Livewire\Login;

use DanHarrin\LivewireRateLimiting\Attributes\RateLimit;
use Livewire\Component;

class Login extends Component
{
    #[RateLimit(maxAttempts: 10, validationErrors: ['email' => 'Too many attempts...'])]
    public function submit()
    {
        // ...
    }
}
```

Let me know if you need any more changes.