### PR TITLE
Support `#[Json]` attribute exception

### DIFF
--- a/src/Exceptions/TooManyRequestsException.php
+++ b/src/Exceptions/TooManyRequestsException.php
@@ -2,9 +2,9 @@
 
 namespace DanHarrin\LivewireRateLimiting\Exceptions;
 
-use Exception;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class TooManyRequestsException extends Exception
+class TooManyRequestsException extends HttpException
 {
     public $minutesUntilAvailable;
 
@@ -14,14 +14,17 @@ class TooManyRequestsException extends Exception
         public $ip,
         public $secondsUntilAvailable,
     ) {
-        $this->minutesUntilAvailable = ceil($this->secondsUntilAvailable / 60);
+        $this->minutesUntilAvailable = ceil($secondsUntilAvailable / 60);
 
-        parent::__construct(sprintf(
-            'Too many requests from [%s] to method [%s] on component: [%s]. Retry in %d seconds.',
-            $this->ip,
-            $this->method,
-            $this->component,
-            $this->secondsUntilAvailable,
-        ));
+        parent::__construct(
+            429,
+            sprintf(
+                'Too many requests from [%s] to method [%s] on component: [%s]. Retry in %d seconds.',
+                $ip,
+                $method,
+                $component,
+                $secondsUntilAvailable,
+            )
+        );
     }
 }

--- a/src/Exceptions/TooManyRequestsException.php
+++ b/src/Exceptions/TooManyRequestsException.php
@@ -16,15 +16,12 @@ class TooManyRequestsException extends HttpException
     ) {
         $this->minutesUntilAvailable = ceil($this->secondsUntilAvailable / 60);
 
-        parent::__construct(
-            429,
-            sprintf(
-                'Too many requests from [%s] to method [%s] on component: [%s]. Retry in %d seconds.',
-                $ip,
-                $method,
-                $component,
-                $secondsUntilAvailable,
-            )
-        );
+        parent::__construct(429, sprintf(
+            'Too many requests from [%s] to method [%s] on component: [%s]. Retry in %d seconds.',
+            $this->ip,
+            $this->method,
+            $this->component,
+            $this->secondsUntilAvailable,
+        ));
     }
 }

--- a/src/Exceptions/TooManyRequestsException.php
+++ b/src/Exceptions/TooManyRequestsException.php
@@ -14,7 +14,7 @@ class TooManyRequestsException extends HttpException
         public $ip,
         public $secondsUntilAvailable,
     ) {
-        $this->minutesUntilAvailable = ceil($secondsUntilAvailable / 60);
+        $this->minutesUntilAvailable = ceil($this->secondsUntilAvailable / 60);
 
         parent::__construct(
             429,

--- a/tests/RateLimitingTest.php
+++ b/tests/RateLimitingTest.php
@@ -3,11 +3,28 @@
 namespace DanHarrin\LivewireRateLimiting\Tests;
 
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use Livewire\Attributes\Json;
 use Livewire\Livewire;
 use Livewire\Volt\Volt;
 
 class RateLimitingTest extends TestCase
 {
+    public function test_rate_limit_throws_exception_with_status_429()
+    {
+        $component = Livewire::test(Component::class);
+
+        $component
+            ->call('fetchJson')
+            ->assertOk()
+            ->call('fetchJson')
+            ->assertOk();
+
+        $returnsMeta = $component->effects['returnsMeta'] ?? [];
+
+        $this->assertArrayHasKey(0, $returnsMeta);
+        $this->assertArrayHasKey('status', $returnsMeta[0]);
+        $this->assertSame(429, $returnsMeta[0]['status']);
+    }
 
     public function test_can_rate_limit()
     {
@@ -112,6 +129,12 @@ class Component extends \Livewire\Component
         }
 
         $this->secondsUntilAvailable = 0;
+    }
+
+    #[Json]
+    public function fetchJson()
+    {
+        $this->rateLimit(1);
     }
 
     public function render()

--- a/tests/RateLimitingTest.php
+++ b/tests/RateLimitingTest.php
@@ -2,6 +2,7 @@
 
 namespace DanHarrin\LivewireRateLimiting\Tests;
 
+use Composer\InstalledVersions;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use Livewire\Attributes\Json;
 use Livewire\Livewire;
@@ -11,6 +12,13 @@ class RateLimitingTest extends TestCase
 {
     public function test_rate_limit_throws_exception_with_status_429()
     {
+        $version = InstalledVersions::getPrettyVersion('livewire/livewire');
+
+        $this->markTestSkippedWhen(
+            version_compare($version, '4.0.0', '<'),
+            'Requires Livewire v4+'
+        );
+
         $component = Livewire::test(Component::class);
 
         $component

--- a/tests/RateLimitingTest.php
+++ b/tests/RateLimitingTest.php
@@ -15,7 +15,7 @@ class RateLimitingTest extends TestCase
         $version = InstalledVersions::getPrettyVersion('livewire/livewire');
 
         $this->markTestSkippedWhen(
-            version_compare($version, '4.0.0', '<'),
+            version_compare($version, 'v4.0.0', '<'),
             'Requires Livewire v4+'
         );
 


### PR DESCRIPTION
## Summary

Makes `TooManyRequestsException` report HTTP status `429` so Livewire` #[Json]` actions reject the client promise with the correct status instead of defaulting to `500`.

## Problem

```php
<?php

use DanHarrin\LivewireRateLimiting\WithRateLimiting;
use Livewire\Attributes\Json;
use Livewire\Component;

new class extends Component
{
    use WithRateLimiting;

    #[Json]
    public function getPost($id)
    {
        $this->rateLimit(10);  // Coult throw TooManyRequestsException

        return Post::find($id);  // Could throw ModelNotFoundException
    }
}
```

Livewire’s `#[Json]` attribute treats component actions as JSON endpoints. When an exception is thrown from such a method, `SupportJson` determines the rejection status like this:

```php
$status = $e instanceof HttpExceptionInterface ? $e->getStatusCode() : 500;
```

The previous `TooManyRequestsException` extended plain `Exception`, so it did not implement `HttpExceptionInterface`. Rate-limit hits on `#[Json]` methods therefore produced:

```php
{ status: 500, body: null, json: null, errors: null }
```

reference: [Json attribute error rejection shape](https://livewire.laravel.com/docs/4.x/attribute-json#error-rejection-shape)

A rate-limit response should be `429 Too Many Requests`, not a generic server error.

## Solution

Change `TooManyRequestsException` to extend Symfony’s `HttpException` and pass status `429` to the parent constructor:

```php
class TooManyRequestsException extends HttpException
{
    public $minutesUntilAvailable;

    public function __construct(
        public $component,
        public $method,
        public $ip,
        public $secondsUntilAvailable,
    ) {
        $this->minutesUntilAvailable = ceil($this->secondsUntilAvailable / 60);

        parent::__construct(
            429,
            sprintf(
                'Too many requests from [%s] to method [%s] on component: [%s]. Retry in %d seconds.',
                $this->ip,
                $this->method,
                $this->component,
                $this->secondsUntilAvailable,
            )
        );
    }
}
```